### PR TITLE
[fix] Fixed the type of `App1713693601IDL` to follow `Idl` Type

### DIFF
--- a/anchor/target/idl/app_1713693601.json
+++ b/anchor/target/idl/app_1713693601.json
@@ -1,7 +1,7 @@
 {
   "address": "5SkVTeXdssuUaVxY2EXuJVnhCtWcgrP1AdF4uTPsBh6k",
   "metadata": {
-    "name": "app_1713693601",
+    "name": "app1713693601",
     "version": "0.1.0",
     "spec": "0.1.0",
     "description": "Created with Anchor"
@@ -26,7 +26,7 @@
           "signer": true
         },
         {
-          "name": "app_1713693601",
+          "name": "app1713693601",
           "writable": true
         }
       ],
@@ -46,7 +46,7 @@
       ],
       "accounts": [
         {
-          "name": "app_1713693601",
+          "name": "app1713693601",
           "writable": true
         }
       ],
@@ -66,7 +66,7 @@
       ],
       "accounts": [
         {
-          "name": "app_1713693601",
+          "name": "app1713693601",
           "writable": true
         }
       ],
@@ -91,12 +91,12 @@
           "signer": true
         },
         {
-          "name": "app_1713693601",
+          "name": "app1713693601",
           "writable": true,
           "signer": true
         },
         {
-          "name": "system_program",
+          "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
       ],
@@ -116,7 +116,7 @@
       ],
       "accounts": [
         {
-          "name": "app_1713693601",
+          "name": "app1713693601",
           "writable": true
         }
       ],
@@ -130,7 +130,7 @@
   ],
   "accounts": [
     {
-      "name": "App1713693601",
+      "name": "app1713693601",
       "discriminator": [
         7,
         240,
@@ -145,7 +145,7 @@
   ],
   "types": [
     {
-      "name": "App1713693601",
+      "name": "app1713693601",
       "type": {
         "kind": "struct",
         "fields": [

--- a/web/components/app-1713693601/app-1713693601-data-access.tsx
+++ b/web/components/app-1713693601/app-1713693601-data-access.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { App1713693601IDL, getApp1713693601ProgramId } from '@app-1713693601/anchor'
+import { App1713693601, App1713693601IDL, getApp1713693601ProgramId } from '@app-1713693601/anchor'
 import { Program } from '@coral-xyz/anchor'
 import { useConnection } from '@solana/wallet-adapter-react'
 import { Cluster, Keypair, PublicKey } from '@solana/web3.js'
@@ -17,7 +17,7 @@ export function useApp1713693601Program() {
   const transactionToast = useTransactionToast()
   const provider = useAnchorProvider()
   const programId = useMemo(() => getApp1713693601ProgramId(cluster.network as Cluster), [cluster])
-  const program = new Program(App1713693601IDL, programId, provider)
+  const program = new Program(App1713693601IDL as App1713693601, provider)
 
   const accounts = useQuery({
     queryKey: ['app-1713693601', 'all', { cluster }],


### PR DESCRIPTION
Before
```js
 const program = new Program(App1713693601IDL, programId, provider)
```
Here, programId was irrelevant as type of Program is `new Program<App1713693601>(idl: App1713693601, provider?: Provider | undefined, ...`
Also, `App1713693601IDL` cannot be directly used from JSON, it first needs to have a corresponding Idl Type defined in `app_1713693601` as `App1713693601` type, which requires to be imported.

After
```js
const program = new Program(App1713693601IDL as App1713693601, provider)
```
Loaded the `App1713693601` which was following the `Idl` Type, which could also be used in the TS file.

Frontend now loads correctly.
<img width="1435" alt="Screenshot 2024-04-21 at 6 46 31 PM" src="https://github.com/beeman/solana-dapp-anchor-v030/assets/120790871/d2f22d0a-5d09-4c4a-b78c-12779c1de021">
@beeman 
